### PR TITLE
ENG-9248 support multiple 403 logs

### DIFF
--- a/package_insights/__init__.py
+++ b/package_insights/__init__.py
@@ -4,21 +4,21 @@ Exposes key functions for easier importing in tests.
 """
 
 from .package_insights import (  # noqa: F401
-    parse_log_for_details,
     extract_action_slug,
     find_package,
     fetch_policies,
     fetch_policy_of_action,
     report_package,
     package_insights,
+    parse_logs_for_all_details,
 )
 
 __all__ = [
-    "parse_log_for_details",
     "extract_action_slug",
     "find_package",
     "fetch_policies",
     "fetch_policy_of_action",
     "report_package",
     "package_insights",
+    "parse_logs_for_all_details",
 ]

--- a/package_insights/package_insights.py
+++ b/package_insights/package_insights.py
@@ -255,7 +255,7 @@ def report_package(package_name: str, pkg: dict, policy_info: str, action_slug: 
     return quarantined # True
 
 # -----------------------------
-# Parsers Functions
+# Parsers
 # -----------------------------
 
 LOG_403_TARBALL_URL_RE = re.compile(

--- a/package_insights/package_insights.py
+++ b/package_insights/package_insights.py
@@ -5,6 +5,14 @@ import click
 import requests
 import re
 from typing import Optional
+from enum import IntEnum
+
+
+class ExitCode(IntEnum):
+    SUCCESS = 0
+    QUARANTINED_DETECTED = 1
+    PARSE_ERROR = 2
+    MISSING_API_KEY = 3
 
 
 # -----------------------------
@@ -17,7 +25,7 @@ def get_api_key() -> str:
         click.secho('❌ Missing API Key', fg='red', bold=True)
         click.echo('   CLOUDSMITH_API_KEY environment variable not set')
         click.secho('💡 Hint: export CLOUDSMITH_API_KEY=your_key_here', fg='blue')
-        sys.exit(1)
+        sys.exit(ExitCode.MISSING_API_KEY)
     return api_key
 
 
@@ -246,6 +254,9 @@ def report_package(package_name: str, pkg: dict, policy_info: str, action_slug: 
 
     return quarantined # True
 
+# -----------------------------
+# Parsers Functions
+# -----------------------------
 
 LOG_403_TARBALL_URL_RE = re.compile(
     r"""
@@ -483,7 +494,7 @@ def _handle_parse_error():
     """Handle error when package details cannot be parsed."""
     click.secho('❌ Unable to parse package details from log', fg='red', bold=True)
     click.echo('   Could not extract package name and version information')
-    sys.exit(2)
+    sys.exit(ExitCode.PARSE_ERROR)
 
 def _handle_package_not_found(package_name, package_version, workspace, repo, follow_up):
     """Handle error when package is not found in repository."""
@@ -541,7 +552,7 @@ def package_insights(log, follow_up):
 
     if quarantined_detected:
         # After reporting all, use exit code 1 to indicate at least one quarantined
-        sys.exit(1)
+        sys.exit(ExitCode.QUARANTINED_DETECTED)
 
 
 

--- a/package_insights/package_insights.py
+++ b/package_insights/package_insights.py
@@ -198,10 +198,7 @@ def report_package(package_name: str, pkg: dict, policy_info: str, action_slug: 
     quarantined = pkg.get('is_quarantined', False)
     version = pkg.get('version')
     
-    # Header with package info
-    click.echo("=" * 60)
-    click.secho("☁️  CLOUDSMITH INSIGHTS ☁️", fg='cyan', bold=True)
-    click.echo("=" * 60)
+    # Package info
     click.secho(f"📦 Package: {package_name}=={version} 📦", fg='white', bold=True)
     click.echo("-" * 40)
     
@@ -244,8 +241,9 @@ def report_package(package_name: str, pkg: dict, policy_info: str, action_slug: 
         click.secho("🎯 Next Steps:", fg='magenta', bold=True)
         click.echo(f"   {follow_up}")
     
-    click.echo("=" * 60)
-    click.secho("❌ PACKAGE QUARANTINED", fg='red', bold=True)
+    click.echo("-" * 40)
+    click.echo()
+
     return quarantined # True
 
 
@@ -269,39 +267,36 @@ class BaseFormatClientParser:
     """Base parser for a (package_format, client) pair.
 
     Subclasses should implement:
-      detect(log_text): return True if this parser applies
+      log_matches_format_and_client(log_text): return True if the logs indicate this is the correct parser
       extract(log_text): yield raw tuples (workspace, repo, package, version)
-      normalize_name(name)
-      normalize_version(version)
+      normalise_name(name)
+      normalise_version(version)
     """
     package_format = "generic"
     client = "generic"
 
-    def detect(self, log_text: str) -> bool:  # pragma: no cover - default
+    def log_matches_format_and_client(self, log_text: str) -> bool:  # pragma: no cover - default
         return False
 
     def extract(self, log_text: str):  # pragma: no cover - default
         return []
 
-    def normalize_name(self, name: str) -> str:
+    def normalise_name(self, name: str) -> str:
         return name
 
-    def normalize_version(self, version: str) -> str:
+    def normalise_version(self, version: str) -> str:
         return version
 
-    def parse(self, log_text: str, unique: bool):
+    def parse(self, log_text: str):
         seen = set()
         results = []
-        for ns, repo, name, ver in self.extract(log_text):
-            name_n = self.normalize_name(name)
-            ver_n = self.normalize_version(ver)
-            tup = (ns, repo, name_n, ver_n)
-            if not unique:
+        for workspace, repo, name, version in self.extract(log_text):
+            normalised_name = self.normalise_name(name)
+            normalised_version = self.normalise_version(version)
+            tup = (workspace, repo, normalised_name, normalised_version)
+            if tup not in seen:
+                seen.add(tup)
                 results.append(tup)
-            else:
-                if tup not in seen:
-                    seen.add(tup)
-                    results.append(tup)
         return results
 
 
@@ -323,7 +318,7 @@ class PythonPipParser(BaseFormatClientParser):
     # Extract from wheel filename e.g. python_gitlab-6.3.0-py3-none-any.whl
     ARTIFACT_FILENAME_RE = re.compile(r"/python/([A-Za-z0-9_.-]+)-([0-9][A-Za-z0-9_.-]*)-py[0-9]", re.IGNORECASE)
 
-    def detect(self, log_text: str) -> bool:
+    def log_matches_format_and_client(self, log_text: str) -> bool:
         return "ERROR: Could not install requirement" in log_text and "python" in log_text
 
     def extract(self, log_text: str):
@@ -369,12 +364,12 @@ class PythonPipParser(BaseFormatClientParser):
             ns, rp, pkg, ver = m.groups()
             yield (ns, rp, pkg, ver)
 
-    def normalize_name(self, name: str) -> str:
+    def normalise_name(self, name: str) -> str:
         # Keep original requested form (hyphens) if present; ensure underscores from artifact names
         # are converted to hyphens for consistency with pip requirement syntax.
         return name.replace('_', '-')
 
-    def normalize_version(self, version: str) -> str:
+    def normalise_version(self, version: str) -> str:
         # Strip trailing wheel/platform qualifiers if they slipped in (defensive)
         if not version:
             return version
@@ -388,18 +383,78 @@ PARSERS: list[BaseFormatClientParser] = [
 ]
 
 
+class NpmParser(BaseFormatClientParser):
+    package_format = "npm"
+    client = "npm"
+
+    # Match signed URL style (npm http fetch GET 403 ... dl.cloudsmith.io/signed/.../npm/<pkg>/<pkg>-<ver>.tgz)
+    NPM_SIGNED_FETCH_RE = re.compile(
+        r"npm http fetch GET 403\s+(https://dl\.cloudsmith\.io/[^\s]+/npm/([A-Za-z0-9_.-]+)/\2-([0-9]+\.[0-9]+\.[0-9]+[^/]*)\.tgz)",
+        re.IGNORECASE,
+    )
+    # Match direct registry http fetch 403 lines (npm http fetch GET 403 https://npm.cloudsmith.io/ws/repo/<pkg>/-/<pkg>-<ver>.tgz)
+    NPM_HTTP_DIRECT_FETCH_RE = re.compile(
+        r"npm http fetch GET 403\s+(https://npm\.cloudsmith\.io/[^\s]+/([A-Za-z0-9_.-]+)/-/\2-([0-9]+\.[0-9]+\.[0-9]+[^/]*)\.tgz)",
+        re.IGNORECASE,
+    )
+    # Match npm.cloudsmith.io style (quarantine message version)
+    NPM_DIRECT_FETCH_RE = re.compile(
+        r"npm error 403 403 Forbidden - GET (https://npm\.cloudsmith\.io/[^\s]+/([A-Za-z0-9_.-]+)/-/\2-([0-9]+\.[0-9]+\.[0-9]+[^/]*)\.tgz)",
+        re.IGNORECASE,
+    )
+    # Generic 403 Forbidden GET (signed) in error line
+    NPM_ERROR_SIGNED_RE = re.compile(
+        r"npm error 403 403 Forbidden - GET (https://dl\.cloudsmith\.io/[^\s]+/npm/([A-Za-z0-9_.-]+)/\2-([0-9]+\.[0-9]+\.[0-9]+[^/]*)\.tgz)",
+        re.IGNORECASE,
+    )
+    WORKSPACE_REPO_FROM_URL_RE = re.compile(r"https://(?:dl|npm)\.cloudsmith\.io/(?:signed/)?([^/]+)/([^/]+)/")
+
+    def log_matches_format_and_client(self, log_text: str) -> bool:
+        return 'npm ' in log_text and '403' in log_text
+
+    def extract(self, log_text: str):
+        matched = False
+        patterns = [
+            self.NPM_SIGNED_FETCH_RE,
+            self.NPM_HTTP_DIRECT_FETCH_RE,
+            self.NPM_DIRECT_FETCH_RE,
+            self.NPM_ERROR_SIGNED_RE,
+        ]
+        for pattern in patterns:
+            for m in pattern.finditer(log_text):
+                full_url, pkg, ver = m.groups()
+                ws_repo = self.WORKSPACE_REPO_FROM_URL_RE.search(full_url)
+                if not ws_repo:
+                    continue
+                workspace, repo = ws_repo.groups()
+                yield (workspace, repo, pkg, ver)
+                matched = True
+        if matched:
+            return
+
+    def normalise_name(self, name: str) -> str:
+        return name  # npm names usually kept as-is (ignoring scoped packages for now)
+
+    def normalise_version(self, version: str) -> str:
+        return version
+
+PARSERS.append(NpmParser())
+
+
 def parse_logs_for_all_details(log_text: str, unique: bool = True):
     """Parse log output for all (workspace, repo, package, version) tuples.
 
     Extensible pipeline:
-      1. Iterate registered parsers; the first whose detect() returns True is used.
+      1. Iterate registered parsers; the first whose log_matches_format_and_client() returns True is used.
       2. If that parser returns results, return them.
-      3. If detection passes but no results extracted, fall through to next parser.
+      3. If detection passes but no results extracted, fall through to next parser 
+        - this allows us to try multiple parsers where similar errors occur 
+        - TODO: it might make more sense to match package format and then iterate through multiple client parsers
       4. Return an empty list if no results found
     """
     for parser in PARSERS:
-        if parser.detect(log_text):
-            results = parser.parse(log_text, unique=unique)
+        if parser.log_matches_format_and_client(log_text):
+            results = parser.parse(log_text)
             if results:
                 return results
     return []
@@ -454,6 +509,11 @@ def package_insights(log, follow_up):
 
     api_key = get_api_key()
     headers = build_headers(api_key)
+
+    # Print Header
+    click.echo("=" * 60)
+    click.secho("☁️  CLOUDSMITH INSIGHTS ☁️", fg='cyan', bold=True)
+    click.echo("=" * 60)
 
     # Track whether any quarantined package exists to triggered an exit code after loop.
     quarantined_detected = False

--- a/package_insights/package_insights.py
+++ b/package_insights/package_insights.py
@@ -135,15 +135,15 @@ def find_package(workspace: str, repo: str, headers: dict, name: str, version: O
             click.echo(f'   Response: {resp.text}')
             return None
         try:
-            payload = resp.json()
+            packages = resp.json()
         except ValueError:
             click.secho(f"⚠️  Invalid JSON response for page {page}", fg='yellow')
             return None
 
-        if isinstance(payload, dict) and 'results' in payload:
-            packages_iter = payload.get('results', [])
+        if isinstance(packages, dict) and 'results' in packages:
+            packages_iter = packages.get('results', [])
         else:
-            packages_iter = payload
+            packages_iter = packages
 
         for pkg in packages_iter:
             if pkg.get('display_name') == name and (version is None or pkg.get('version') == version):

--- a/package_insights/package_insights.py
+++ b/package_insights/package_insights.py
@@ -215,7 +215,7 @@ def report_package(package_name: str, pkg: dict, policy_info: str, action_slug: 
             click.secho("🎯 Next Steps:", fg='magenta', bold=True)
             click.echo(f"   {follow_up}")
         click.echo("=" * 60)
-        return False  # not quarantined
+        return quarantined  # False
     
     # Quarantined package
     click.secho("🚫 Status: QUARANTINED", fg='red', bold=True)

--- a/package_insights/package_insights.py
+++ b/package_insights/package_insights.py
@@ -1,4 +1,5 @@
 import os
+from urllib.parse import quote as _urlquote
 import sys
 import click
 import requests
@@ -27,9 +28,9 @@ def build_headers(api_key: str) -> dict:
     }
 
 
-def fetch_policies(namespace: str, headers: dict) -> dict:
+def fetch_policies(workspace: str, headers: dict) -> dict:
     """Return a dict of policy_slug_perm -> policy object."""
-    base_url = f"https://api.cloudsmith.io/v2/workspaces/{namespace}/policies/"
+    base_url = f"https://api.cloudsmith.io/v2/workspaces/{workspace}/policies/"
     page = 1
     total_pages = None
     policies = {}
@@ -63,9 +64,9 @@ def fetch_policies(namespace: str, headers: dict) -> dict:
             break
     return policies
 
-def fetch_policy_of_action(namespace: str, headers: dict, action_slug: str) -> str|None:
+def fetch_policy_of_action(workspace: str, headers: dict, action_slug: str) -> str|None:
     """Return a dict of policy_slug_perm -> policy object."""
-    base_url = f"https://api.cloudsmith.io/v2/workspaces/{namespace}/policies/"
+    base_url = f"https://api.cloudsmith.io/v2/workspaces/{workspace}/policies/"
     page = 1
     total_pages = None
 
@@ -83,7 +84,7 @@ def fetch_policy_of_action(namespace: str, headers: dict, action_slug: str) -> s
             break
         for policy in data.get('results', []):
             slug = policy.get('slug_perm')
-            actions_url = f"https://api.cloudsmith.io/v2/workspaces/{namespace}/policies/{slug}/actions/"
+            actions_url = f"https://api.cloudsmith.io/v2/workspaces/{workspace}/policies/{slug}/actions/"
             resp = requests.get(actions_url, headers=headers)
             if resp.status_code != 200:
                 click.secho(f"⚠️  Could not fetch actions for policy '{slug}' (HTTP {resp.status_code})", fg='yellow')
@@ -115,60 +116,49 @@ def parse_package_entry(entry: str):
     return entry, None
 
 
-def find_package(namespace: str, repo: str, headers: dict, name: str, version: Optional[str]):
-    """Iterate each package page until the (name, version) match is found or pages exhausted.
+def find_package(workspace: str, repo: str, headers: dict, name: str, version: Optional[str]):
+    """Locate a package using Cloudsmith packages API."""
 
-    Cloudsmith pagination headers used:
-      x-pagination-pagetotal -> total number of pages (int)
-      x-pagination-count     -> current page (int) (provided in user description)
-    We request sequential pages and stop early once we locate the desired package.
-    """
-    base_url = f"https://api.cloudsmith.io/packages/{namespace}/{repo}/"
+    base_url = f"https://api.cloudsmith.io/packages/{workspace}/{repo}/"
+    
+    query_term = name if not version else f"name:{name} AND version:{version}"
     page = 1
     total_pages = None
-
     while True:
-        url = f"{base_url}?sort=-date&page={page}"
+        url = f"{base_url}?sort=-date&query={_urlquote(query_term)}&page={page}"
         resp = requests.get(url, headers=headers)
         if resp.status_code != 200:
             click.secho(
-                f"⚠️  Failed to list packages (page {page}) in {namespace}/{repo} (HTTP {resp.status_code})",
+                f"⚠️  Failed to list packages (page {page}) in {workspace}/{repo} (HTTP {resp.status_code})",
                 fg='yellow'
             )
-            click.echo(
-                f'   Response: {resp.text}'
-            )
+            click.echo(f'   Response: {resp.text}')
             return None
-
         try:
-            packages = resp.json()
+            payload = resp.json()
         except ValueError:
             click.secho(f"⚠️  Invalid JSON response for page {page}", fg='yellow')
             return None
 
-        if isinstance(packages, dict) and 'results' in packages:
-            packages_iter = packages.get('results', [])
+        if isinstance(payload, dict) and 'results' in payload:
+            packages_iter = payload.get('results', [])
         else:
-            packages_iter = packages
+            packages_iter = payload
 
         for pkg in packages_iter:
-            if pkg.get('display_name') == name:
-                if version is None or pkg.get('version') == version:
-                    return pkg
+            if pkg.get('display_name') == name and (version is None or pkg.get('version') == version):
+                return pkg
 
-        # Determine total pages (one-time)
         if total_pages is None:
             total_header = resp.headers.get('x-pagination-pagetotal')
             if total_header and total_header.isdigit():
                 total_pages = int(total_header)
             else:
-                # If no pagination headers, assume single page
-                return None
-
+                # No pagination headers -> assume single page; stop.
+                break
         page += 1
         if total_pages is not None and page > total_pages:
             break
-
     return None
 
 
@@ -182,12 +172,12 @@ def extract_action_slug(status_reason: str) -> Optional[str]:
     return m.group(1) if m else None
 
 
-def find_policy_for_action_slug(policies: dict, action_slug: str, namespace: str, headers: dict) -> Optional[str]:
+def find_policy_for_action_slug(policies: dict, action_slug: str, workspace: str, headers: dict) -> Optional[str]:
     """Iterate policies and their actions to find which policy contains the action slug."""
     if not action_slug:
         return None
     for policy_slug, policy in policies.items():
-        actions_url = f"https://api.cloudsmith.io/v2/workspaces/{namespace}/policies/{policy_slug}/actions/"
+        actions_url = f"https://api.cloudsmith.io/v2/workspaces/{workspace}/policies/{policy_slug}/actions/"
         resp = requests.get(actions_url, headers=headers)
         if resp.status_code != 200:
             click.secho(f"⚠️  Could not fetch actions for policy '{policy_slug}' (HTTP {resp.status_code})", fg='yellow')
@@ -228,7 +218,7 @@ def report_package(package_name: str, pkg: dict, policy_info: str, action_slug: 
             click.secho("🎯 Next Steps:", fg='magenta', bold=True)
             click.echo(f"   {follow_up}")
         click.echo("=" * 60)
-        return
+        return False  # not quarantined
     
     # Quarantined package
     click.secho("🚫 Status: QUARANTINED", fg='red', bold=True)
@@ -247,7 +237,7 @@ def report_package(package_name: str, pkg: dict, policy_info: str, action_slug: 
     else:
         click.echo()
         click.secho("🛡️  POLICY DETAILS:", fg='blue', bold=True)
-        click.echo("   No associated policy found")
+        click.echo("   No associated policy found - this can happen when the action has occurred but since been deleted")
     
     if follow_up:
         click.echo()
@@ -256,7 +246,7 @@ def report_package(package_name: str, pkg: dict, policy_info: str, action_slug: 
     
     click.echo("=" * 60)
     click.secho("❌ PACKAGE QUARANTINED", fg='red', bold=True)
-    sys.exit(1)
+    return quarantined # True
 
 
 LOG_403_TARBALL_URL_RE = re.compile(
@@ -264,7 +254,7 @@ LOG_403_TARBALL_URL_RE = re.compile(
     (?:.*403.*?)?                              # Optional: any text before '403', non-greedy
     https://dl\.cloudsmith\.io/                # Match the base Cloudsmith URL
     [^/]+/                                     # Match the domain segment (not captured)
-    ([^/]+)/                                   # Capture group 1: namespace
+    ([^/]+)/                                   # Capture group 1: workspace
     ([^/]+)/                                   # Capture group 2: repo
     python/                                    # Match the 'python' segment
     ([A-Za-z0-9_.-]+)-                         # Capture group 3: package name
@@ -274,14 +264,145 @@ LOG_403_TARBALL_URL_RE = re.compile(
     """,
     re.VERBOSE
 )
-def parse_log_for_details(log_text: str):
-    """Extract namespace, repo, package name and version from log output."""
 
-    m = LOG_403_TARBALL_URL_RE.search(log_text)
-    if m:
-        namespace, repo, pkg, ver = m.groups()
-        return namespace, repo, pkg, ver
-    return None, None, None, None
+class BaseFormatClientParser:
+    """Base parser for a (package_format, client) pair.
+
+    Subclasses should implement:
+      detect(log_text): return True if this parser applies
+      extract(log_text): yield raw tuples (workspace, repo, package, version)
+      normalize_name(name)
+      normalize_version(version)
+    """
+    package_format = "generic"
+    client = "generic"
+
+    def detect(self, log_text: str) -> bool:  # pragma: no cover - default
+        return False
+
+    def extract(self, log_text: str):  # pragma: no cover - default
+        return []
+
+    def normalize_name(self, name: str) -> str:
+        return name
+
+    def normalize_version(self, version: str) -> str:
+        return version
+
+    def parse(self, log_text: str, unique: bool):
+        seen = set()
+        results = []
+        for ns, repo, name, ver in self.extract(log_text):
+            name_n = self.normalize_name(name)
+            ver_n = self.normalize_version(ver)
+            tup = (ns, repo, name_n, ver_n)
+            if not unique:
+                results.append(tup)
+            else:
+                if tup not in seen:
+                    seen.add(tup)
+                    results.append(tup)
+        return results
+
+
+class PythonPipParser(BaseFormatClientParser):
+    package_format = "python"
+    client = "pip"
+
+    # Match name==version from error log
+    ERROR_COULD_NOT_INSTALL_RE = re.compile(
+        r"ERROR: Could not install requirement\s+([A-Za-z0-9_.-]+)==([0-9][A-Za-z0-9_.-]*)\s+from\s+(https://dl\.cloudsmith\.io/[^\s)]+)",
+        re.IGNORECASE,
+    )
+    # Match name from error log (pip install called without specific version)
+    ERROR_COULD_NOT_INSTALL_NO_VER_RE = re.compile(
+        r"ERROR: Could not install requirement\s+([A-Za-z0-9_.-]+)\s+from\s+(https://dl\.cloudsmith\.io/[^\s)]+)",
+        re.IGNORECASE,
+    )
+    WORKSPACE_REPO_FROM_URL_RE = re.compile(r"https://dl\.cloudsmith\.io/[^/]+/([^/]+)/([^/]+)/python/")
+    # Extract from wheel filename e.g. python_gitlab-6.3.0-py3-none-any.whl
+    ARTIFACT_FILENAME_RE = re.compile(r"/python/([A-Za-z0-9_.-]+)-([0-9][A-Za-z0-9_.-]*)-py[0-9]", re.IGNORECASE)
+
+    def detect(self, log_text: str) -> bool:
+        return "ERROR: Could not install requirement" in log_text and "python" in log_text
+
+    def extract(self, log_text: str):
+        # First: explicit version form
+        matched = False
+        for m in self.ERROR_COULD_NOT_INSTALL_RE.finditer(log_text):
+            pkg, ver, url = m.groups()
+            nsrp = self.WORKSPACE_REPO_FROM_URL_RE.search(url)
+            if not nsrp:
+                continue
+            workspace, repo = nsrp.groups()
+            yield (workspace, repo, pkg, ver)
+            matched = True
+        if matched:
+            return
+
+        # Second: no-version form; derive version from artifact filename if possible
+        for m in self.ERROR_COULD_NOT_INSTALL_NO_VER_RE.finditer(log_text):
+            pkg, url = m.groups()
+            nsrp = self.WORKSPACE_REPO_FROM_URL_RE.search(url)
+            if not nsrp:
+                continue
+            workspace, repo = nsrp.groups()
+            ver = None
+            art = self.ARTIFACT_FILENAME_RE.search(url)
+            if art:
+                wheel_name, wheel_ver = art.groups()
+                ver = wheel_ver
+            else:
+                # As a fallback attempt to pull version from any artifact URL in log
+                art2 = self.ARTIFACT_FILENAME_RE.search(log_text)
+                if art2:
+                    _, wheel_ver = art2.groups()
+                    ver = wheel_ver
+            if ver:
+                yield (workspace, repo, pkg, ver)
+                matched = True
+        if matched:
+            return
+
+        # Fallback: artifact URLs
+        for m in LOG_403_TARBALL_URL_RE.finditer(log_text):
+            ns, rp, pkg, ver = m.groups()
+            yield (ns, rp, pkg, ver)
+
+    def normalize_name(self, name: str) -> str:
+        # Keep original requested form (hyphens) if present; ensure underscores from artifact names
+        # are converted to hyphens for consistency with pip requirement syntax.
+        return name.replace('_', '-')
+
+    def normalize_version(self, version: str) -> str:
+        # Strip trailing wheel/platform qualifiers if they slipped in (defensive)
+        if not version:
+            return version
+        # Match PEP 440-compliant version strings: X.Y, X.Y.Z, and optional pre/post/dev tags
+        m = re.match(r"^(\d+\.\d+(?:\.\d+)?(?:[a-zA-Z0-9_.-]*)?)$", version)
+        return m.group(1) if m else version
+
+
+PARSERS: list[BaseFormatClientParser] = [
+    PythonPipParser(),
+]
+
+
+def parse_logs_for_all_details(log_text: str, unique: bool = True):
+    """Parse log output for all (workspace, repo, package, version) tuples.
+
+    Extensible pipeline:
+      1. Iterate registered parsers; the first whose detect() returns True is used.
+      2. If that parser returns results, return them.
+      3. If detection passes but no results extracted, fall through to next parser.
+      4. Return an empty list if no results found
+    """
+    for parser in PARSERS:
+        if parser.detect(log_text):
+            results = parser.parse(log_text, unique=unique)
+            if results:
+                return results
+    return []
 
 
 def _read_log_text(log):
@@ -309,48 +430,58 @@ def _handle_parse_error():
     click.echo('   Could not extract package name and version information')
     sys.exit(2)
 
-def _handle_package_not_found(package_name, package_version, namespace, repo, follow_up):
+def _handle_package_not_found(package_name, package_version, workspace, repo, follow_up):
     """Handle error when package is not found in repository."""
     click.secho(f'❌ Package not found: {package_name}=={package_version}', fg='red', bold=True)
-    click.echo(f'   Not present in repository: {namespace}/{repo}')
+    click.echo(f'   Not present in repository: {workspace}/{repo}')
     if follow_up:
         click.echo()
         click.secho("🎯 Next Steps:", fg='magenta', bold=True)
         click.echo(f"   {follow_up}")
-    sys.exit(5)
 
 @click.command()
 @click.argument('log', nargs=1)
 @click.option('--follow-up', 'follow_up', required=False, help='Custom follow-up instructions to display with results.')
 def package_insights(log, follow_up):
-    """Parse a pip install log, derive package + namespace/repo, then look up quarantine/policy info."""
+    """Parse a pip install log, derive package + workspace/repo, then look up quarantine/policy info."""
     log_text = _read_log_text(log)
     if not _validate_log(log_text):
         return
-    namespace, repo, package_name, package_version = parse_log_for_details(log_text)
-    if not package_name:
+    matches = parse_logs_for_all_details(log_text, unique=True)
+    if not matches:
         _handle_parse_error()
         return
+
     api_key = get_api_key()
     headers = build_headers(api_key)
-    match = find_package(namespace, repo, headers, package_name, package_version)
-    if match is None:
-        click.secho(f'❌ Package not found: {package_name}=={package_version}', fg='red', bold=True)
-        click.echo(f'   Not present in repository: {namespace}/{repo}')
-        if follow_up:
-            click.echo()
-            click.secho("🎯 Next Steps:", fg='magenta', bold=True)
-            click.echo(f"   {follow_up}")
-        sys.exit(5)
 
-    status_reason = match.get('status_reason', 'No reason provided')
-    action_slug = extract_action_slug(status_reason)
+    # Track whether any quarantined package exists to triggered an exit code after loop.
+    quarantined_detected = False
+    for workspace, repo, package_name, package_version in matches:
+        match = find_package(workspace, repo, headers, package_name, package_version)
+        if match is None:
+            # Report missing package but continue processing remaining packages.
+            _handle_package_not_found(package_name, package_version, workspace, repo, follow_up)
+            continue
 
-    policy_info = None
-    if action_slug:
-        policy_info = fetch_policy_of_action(namespace, headers, action_slug)
+        status_reason = match.get('status_reason', 'No reason provided')
+        action_slug = extract_action_slug(status_reason)
+        policy_info = None
+        if action_slug:
+            policy_info = fetch_policy_of_action(workspace, headers, action_slug)
+        quarantined = report_package(
+            package_name,
+            match,
+            policy_info,
+            action_slug,
+            follow_up=follow_up
+        )
+        if quarantined:
+            quarantined_detected = True
 
-    report_package(package_name, match, policy_info, action_slug, follow_up=follow_up)
+    if quarantined_detected:
+        # After reporting all, use exit code 1 to indicate at least one quarantined
+        sys.exit(1)
 
 
 

--- a/package_insights/test_package_insights_cli.py
+++ b/package_insights/test_package_insights_cli.py
@@ -63,7 +63,7 @@ def test_cli_non_403_log_exits_gracefully(runner, monkeypatch):
 def test_cli_parse_error_exit_code_2(runner, monkeypatch):
 
     # Includes 403 and python but malformed so regex doesn't match
-    log_text = "403 some python content but no package artifact filename"
+    log_text = "ERROR: Could not install requirement some python content but no package artifact filename due to 403"
 
     def fake_get(url, headers=None):  # pragma: no cover - shouldn't be reached due to parse failure
         raise AssertionError("Should not perform HTTP requests when parse fails")
@@ -74,10 +74,10 @@ def test_cli_parse_error_exit_code_2(runner, monkeypatch):
     assert "Unable to parse package details" in result.output
 
 
-def test_cli_package_not_found_exit_code_5(runner, monkeypatch):
+def test_cli_package_not_found(runner, monkeypatch):
 
     # Valid artifact URL pattern
-    log_text = "403 https://dl.cloudsmith.io/public/ns/repo/python/mypkg-1.0.0.tar.gz"
+    log_text = "ERROR: Could not install requirement mypkg==1.0.0 https://dl.cloudsmith.io/public/ns/repo/python/mypkg-1.0.0.tar.gz because of HTTP error 403 Client Error: Forbidden for url"
 
     def fake_get(url, headers=None):
         assert "packages/ns/repo/" in url
@@ -87,12 +87,11 @@ def test_cli_package_not_found_exit_code_5(runner, monkeypatch):
 
     monkeypatch.setattr(package_insights_module.requests, "get", fake_get)
     result = runner.invoke(package_insights, [log_text])
-    assert result.exit_code == 5
     assert "Package not found: mypkg==1.0.0" in result.output
 
 
 def test_cli_blocked_package_success(runner, monkeypatch):
-    log_text = "403 https://dl.cloudsmith.io/public/acme/tools/python/samplepkg-2.1.0.whl"
+    log_text = "ERROR: Could not install requirement samplepkg==2.1.0 https://dl.cloudsmith.io/public/acme/tools/python/samplepkg-2.1.0.whl because of HTTP error 403 Client Error: Forbidden for url"
 
     package_payload = [_build_package("samplepkg", "2.1.0", quarantined=False, status_reason=None)]
 
@@ -114,7 +113,7 @@ def test_cli_blocked_package_success(runner, monkeypatch):
 
 
 def test_cli_quarantined_package_exit_code_1(runner, monkeypatch):
-    log_text = "403 https://dl.cloudsmith.io/public/acme/tools/python/infectedpkg-3.0.0.tar.gz"
+    log_text = "ERROR: Could not install requirement infectedpkg==3.0.0 https://dl.cloudsmith.io/public/acme/tools/python/infectedpkg-3.0.0.tar.gz because of HTTP error 403 Client Error: Forbidden for url"
 
     # Action slug that will be extracted
     action_slug = "ACT123"
@@ -151,9 +150,9 @@ def test_cli_quarantined_package_exit_code_1(runner, monkeypatch):
 
 def test_cli_quarantined_package_no_policy_match(runner, monkeypatch):
     """Quarantined package where action slug doesn't resolve to a policy action."""
-    log_text = "403 https://dl.cloudsmith.io/public/acme/tools/python/quarpkg-9.9.tar.gz"
+    log_text = "ERROR: Could not install requirement quarpkg==9.9.9 https://dl.cloudsmith.io/public/acme/tools/python/quarpkg-9.9.9.tar.gz because of HTTP error 403 Client Error: Forbidden for url"
     status_reason = "Quarantined by slug_perm 'NO_MATCH'"
-    package_payload = [_build_package("quarpkg", "9.9", quarantined=True, status_reason=status_reason)]
+    package_payload = [_build_package("quarpkg", "9.9.9", quarantined=True, status_reason=status_reason)]
 
     def fake_get(url, headers=None):
         if "packages/acme/tools" in url:
@@ -168,3 +167,107 @@ def test_cli_quarantined_package_no_policy_match(runner, monkeypatch):
     assert "PACKAGE QUARANTINED" in result.output
     # No policy details section should appear
     assert "No associated policy found" in result.output
+
+
+def test_cli_multiple_blocked_packages(runner, monkeypatch):
+    monkeypatch.setenv("CLOUDSMITH_API_KEY", "dummy")
+    log_text = (
+        "ERROR: Could not install requirement pkg1==1.0.0 https://dl.cloudsmith.io/public/acme/tools/python/pkg1-1.0.0.tar.gz because of HTTP error 403 Client Error: Forbidden for url\n"
+        "ERROR: Could not install requirement pkg2==2.0.0 https://dl.cloudsmith.io/public/acme/tools/python/pkg2-2.0.0.whl because of HTTP error 403 Client Error: Forbidden for url\n"
+        # duplicate (should be deduped)
+        "ERROR: Could not install requirement pkg1==1.0.0 https://dl.cloudsmith.io/public/acme/tools/python/pkg1-1.0.0.tar.gz because of HTTP error 403 Client Error: Forbidden for url\n"
+    )
+
+    packages_payload = [
+        _build_package("pkg1", "1.0.0", quarantined=False, status_reason=None),
+        _build_package("pkg2", "2.0.0", quarantined=False, status_reason=None),
+    ]
+
+    def fake_get(url, headers=None):
+        if "packages/acme/tools" in url:
+            return _MockResponse(packages_payload, headers={"x-pagination-pagetotal": "1"})
+        if url.startswith("https://api.cloudsmith.io/v2/workspaces/acme/policies/") and "/actions/" not in url:
+            return _MockResponse({"results": []}, headers={"x-pagination-pagetotal": "1"})
+        raise AssertionError(f"Unexpected URL {url}")
+
+    monkeypatch.setattr(package_insights_module.requests, "get", fake_get)
+    result = runner.invoke(package_insights, [log_text])
+    assert result.exit_code == 0
+    # Both packages should appear once
+    assert result.output.count("pkg1==1.0.0") == 1
+    assert result.output.count("pkg2==2.0.0") == 1
+
+
+def test_cli_multiple_with_quarantined_reports_all(runner, monkeypatch):
+    monkeypatch.setenv("CLOUDSMITH_API_KEY", "dummy")
+    action_slug = "ACTZ"
+    status_reason_quar = "Quarantined by slug_perm 'ACTZ'"
+    log_text = (
+        "ERROR: Could not install requirement cleanpkg==1.0.0 https://dl.cloudsmith.io/public/acme/tools/python/cleanpkg-1.0.0.tar.gz because of HTTP error 403 Client Error: Forbidden for url\n"
+        "ERROR: Could not install requirement badpkg==2.0.0 https://dl.cloudsmith.io/public/acme/tools/python/badpkg-2.0.0.whl because of HTTP error 403 Client Error: Forbidden for url\n"
+    )
+    packages_payload = [
+        _build_package("cleanpkg", "1.0.0", quarantined=False, status_reason=None),
+        _build_package("badpkg", "2.0.0", quarantined=True, status_reason=status_reason_quar),
+    ]
+    policies = [{"slug_perm": "policy-x", "name": "Policy X", "description": "Desc"}]
+    actions = {"results": [{"slug_perm": action_slug, "effect": "QUARANTINE"}]}
+
+    def fake_get(url, headers=None):
+        if "packages/acme/tools" in url:
+            return _MockResponse(packages_payload, headers={"x-pagination-pagetotal": "1"})
+        if url.startswith("https://api.cloudsmith.io/v2/workspaces/acme/policies/") and "/actions/" not in url:
+            return _MockResponse({"results": policies}, headers={"x-pagination-pagetotal": "1"})
+        if url.startswith("https://api.cloudsmith.io/v2/workspaces/acme/policies/policy-x/actions/"):
+            return _MockResponse(actions, headers={"x-pagination-pagetotal": "1"})
+        raise AssertionError(f"Unexpected URL {url}")
+
+    monkeypatch.setattr(package_insights_module.requests, "get", fake_get)
+    result = runner.invoke(package_insights, [log_text])
+    # exit code 1 due to quarantined package, but both packages should be reported
+    assert result.exit_code == 1
+    assert "cleanpkg==1.0.0" in result.output
+    assert "badpkg==2.0.0" in result.output
+    assert "PACKAGE QUARANTINED" in result.output
+
+
+def test_cli_four_packages_second_missing_continues(runner, monkeypatch):
+    """Missing second package is reported but later packages are still processed (no early exit)."""
+    log_text = (
+        "ERROR: Could not install requirement pkgA==1.0.0 https://dl.cloudsmith.io/public/acme/tools/python/pkgA-1.0.0.tar.gz because of HTTP error 403 Client Error: Forbidden for url\n"
+        "ERROR: Could not install requirement missingpkg==2.0.0 https://dl.cloudsmith.io/public/acme/tools/python/missingpkg-2.0.0.whl because of HTTP error 403 Client Error: Forbidden for url\n"
+        "ERROR: Could not install requirement pkgC==3.0.0 https://dl.cloudsmith.io/public/acme/tools/python/pkgC-3.0.0.whl because of HTTP error 403 Client Error: Forbidden for url\n"
+        "ERROR: Could not install requirement pkgD==4.0.0 https://dl.cloudsmith.io/public/acme/tools/python/pkgD-4.0.0.whl because of HTTP error 403 Client Error: Forbidden for url\n"
+    )
+
+    def fake_get(url, headers=None):
+        if "packages/acme/tools" in url:
+            if "pkgA" in url:
+                return _MockResponse([
+                    _build_package("pkgA", "1.0.0", quarantined=False, status_reason=None),
+                ], headers={"x-pagination-pagetotal": "1"})
+            if "missingpkg" in url:
+                return _MockResponse([
+                    _build_package("other", "9.9.9", quarantined=False, status_reason=None),
+                ], headers={"x-pagination-pagetotal": "1"})
+            if "pkgC" in url:
+                return _MockResponse([
+                    _build_package("pkgC", "3.0.0", quarantined=False, status_reason=None),
+                ], headers={"x-pagination-pagetotal": "1"})
+            if "pkgD" in url:
+                return _MockResponse([
+                    _build_package("pkgD", "4.0.0", quarantined=False, status_reason=None),
+                ], headers={"x-pagination-pagetotal": "1"})
+        raise AssertionError(f"Unexpected URL {url}")
+
+    monkeypatch.setattr(package_insights_module.requests, "get", fake_get)
+    result = runner.invoke(package_insights, [log_text])
+    # Exit code should be 0 (no quarantined packages) despite one missing
+    assert result.exit_code == 0
+    # First package reported
+    assert "pkgA==1.0.0" in result.output
+    # Missing package message present
+    assert "Package not found: missingpkg==2.0.0" in result.output
+    # Subsequent packages still processed
+    assert "pkgC==3.0.0" in result.output
+    assert "pkgD==4.0.0" in result.output

--- a/package_insights/test_package_insights_cli.py
+++ b/package_insights/test_package_insights_cli.py
@@ -143,7 +143,7 @@ def test_cli_quarantined_package_exit_code_1(runner, monkeypatch):
     monkeypatch.setattr(package_insights_module.requests, "get", fake_get)
     result = runner.invoke(package_insights, [log_text])
     assert result.exit_code == 1
-    assert "PACKAGE QUARANTINED" in result.output
+    assert "Status: QUARANTINED" in result.output
     assert "Quarantine Policy" in result.output
     assert action_slug in result.output
 
@@ -164,13 +164,12 @@ def test_cli_quarantined_package_no_policy_match(runner, monkeypatch):
     monkeypatch.setattr(package_insights_module.requests, "get", fake_get)
     result = runner.invoke(package_insights, [log_text])
     assert result.exit_code == 1
-    assert "PACKAGE QUARANTINED" in result.output
+    assert "Status: QUARANTINED" in result.output
     # No policy details section should appear
     assert "No associated policy found" in result.output
 
 
 def test_cli_multiple_blocked_packages(runner, monkeypatch):
-    monkeypatch.setenv("CLOUDSMITH_API_KEY", "dummy")
     log_text = (
         "ERROR: Could not install requirement pkg1==1.0.0 https://dl.cloudsmith.io/public/acme/tools/python/pkg1-1.0.0.tar.gz because of HTTP error 403 Client Error: Forbidden for url\n"
         "ERROR: Could not install requirement pkg2==2.0.0 https://dl.cloudsmith.io/public/acme/tools/python/pkg2-2.0.0.whl because of HTTP error 403 Client Error: Forbidden for url\n"
@@ -199,7 +198,6 @@ def test_cli_multiple_blocked_packages(runner, monkeypatch):
 
 
 def test_cli_multiple_with_quarantined_reports_all(runner, monkeypatch):
-    monkeypatch.setenv("CLOUDSMITH_API_KEY", "dummy")
     action_slug = "ACTZ"
     status_reason_quar = "Quarantined by slug_perm 'ACTZ'"
     log_text = (
@@ -228,7 +226,7 @@ def test_cli_multiple_with_quarantined_reports_all(runner, monkeypatch):
     assert result.exit_code == 1
     assert "cleanpkg==1.0.0" in result.output
     assert "badpkg==2.0.0" in result.output
-    assert "PACKAGE QUARANTINED" in result.output
+    assert "Status: QUARANTINED" in result.output
 
 
 def test_cli_four_packages_second_missing_continues(runner, monkeypatch):

--- a/package_insights/test_package_insights_parse.py
+++ b/package_insights/test_package_insights_parse.py
@@ -65,6 +65,20 @@ class TestPythonLogParsing:
         )
         assert parse_logs_for_all_details(log)[0] == ("ws", "repo", "python-gitlab", "6.3.0")
 
+    def test_python_no_version_fallback_looks_elsewhere_for_artifact(self):
+        # URL in error line lacks artifact filename so version must be discovered elsewhere in log
+        log = (
+            "ERROR: Could not install requirement fallbackpkg from https://dl.cloudsmith.io/public/ws2/repo2/python/simple/fallbackpkg/ because of HTTP error 403 Client Error: Forbidden for url\n"
+            "Downloading https://dl.cloudsmith.io/public/ws2/repo2/python/fallbackpkg-2.4.0-py3-none-any.whl (15 kB)\n"
+        )
+        assert parse_logs_for_all_details(log)[0] == ("ws2", "repo2", "fallbackpkg", "2.4.0")
+
+    def test_python_fallback_tarball_url_only(self):
+        # Error line lacks package name or version so package info is discovered elsewhere in log
+        log = "ERROR: Could not install requirement https://dl.cloudsmith.io/public/acme/observability/python/agentlib-1.9.0.tar.gz\n"
+
+        assert parse_logs_for_all_details(log)[0] == ("acme", "observability", "agentlib", "1.9.0")
+
 
 class TestNpmLogParsing:
     @pytest.fixture(autouse=True)
@@ -110,6 +124,22 @@ class TestNpmLogParsing:
         assert ("workspace-name", "repository-name", "xmlbuilder", "11.0.1") in matches
         assert ("workspace-name", "repository-name", "querystring", "0.2.0") in matches
         assert ("workspace-name", "repository-name", "url", "0.10.3") in matches
+
+    def test_parse_npm_detection_no_match_returns_empty(self):
+        # Contains 'npm ' and '403' to trigger detection, but no recognized patterns
+        log = (
+            "npm WARN 403 rate limit exceeded for token\n"
+            "npm info attempt registry ping\n"
+        )
+        assert parse_logs_for_all_details(log) == []
+
+    def test_parse_npm_duplicate_signed_fetch_dedup(self):
+        log = (
+            "npm http fetch GET 403 https://dl.cloudsmith.io/signed/wsA/repoA/upstream/x/npm/dup/dup-0.1.0.tgz?created=1&expires=2 10ms\n"
+            "npm http fetch GET 403 https://dl.cloudsmith.io/signed/wsA/repoA/upstream/x/npm/dup/dup-0.1.0.tgz?created=1&expires=2 11ms\n"  # duplicate
+        )
+        matches = parse_logs_for_all_details(log)
+        assert matches == [("wsA", "repoA", "dup", "0.1.0")]
 
 
 class TestLogParsing:

--- a/package_insights/test_package_insights_parse.py
+++ b/package_insights/test_package_insights_parse.py
@@ -1,57 +1,68 @@
 import pytest
-from package_insights.package_insights import parse_log_for_details
+from package_insights.package_insights import parse_logs_for_all_details
 
 
 @pytest.mark.parametrize(
     "log_text,expected",
     [
         (
-            "ERROR 403 while downloading https://dl.cloudsmith.io/public/myspace/myrepo/python/pkgname-1.2.3.tar.gz (for user)",
-            ("myspace", "myrepo", "pkgname", "1.2.3"),
-        ),
-        (
-            # Should still parse even without explicit 403 in the same line
-            "Downloading https://dl.cloudsmith.io/public/team/repo/python/cool_pkg-0.9.0rc1.whl ...",
-            ("team", "repo", "cool_pkg", "0.9.0rc1"),
-        ),
-        (
-            "Some preface ... 403 Forbidden: https://dl.cloudsmith.io/public/ns/rp/python/another.pkg-10.4.zip end",
-            ("ns", "rp", "another.pkg", "10.4"),
-        ),
-        (
-            "403 GET https://dl.cloudsmith.io/public/org/rp-python/python/my_pkg_name-1.0b2.tar.gz",
-            ("org", "rp-python", "my_pkg_name", "1.0b2"),
-        ),
+            """
+            Looking in indexes: https://dl.cloudsmith.io/pzvJ5VJQLGivg1uL/mark-testing/python-stuff/python/simple/
+            Collecting python-gitlab==3.1.1
+            WARNING: Retrying (Retry(total=4, connect=None, read=None, redirect=None, status=None)) after connection broken by 'ReadTimeoutError("HTTPSConnectionPool(host='dl.cloudsmith.io', port=443): Read timed out. (read timeout=15)")': /pzvJ5VJQLGivg1uL/mark-testing/python-stuff/python/python_gitlab-3.1.1-py3-none-any.whl
+            ERROR: HTTP error 403 while getting https://dl.cloudsmith.io/pzvJ5VJQLGivg1uL/mark-testing/python-stuff/python/python_gitlab-3.1.1-py3-none-any.whl#sha256=2a7de39c8976db6d0db20031e71b3e43d262e99e64b471ef09bf00482cd3d9fa (from https://dl.cloudsmith.io/pzvJ5VJQLGivg1uL/mark-testing/python-stuff/python/simple/python-gitlab/) (requires-python:>=3.7.0)
+
+            [notice] A new release of pip is available: 25.1.1 -> 25.2
+            [notice] To update, run: pip install --upgrade pip
+            ERROR: Could not install requirement python-gitlab==3.1.1 from https://dl.cloudsmith.io/pzvJ5VJQLGivg1uL/mark-testing/python-stuff/python/python_gitlab-3.1.1-py3-none-any.whl#sha256=2a7de39c8976db6d0db20031e71b3e43d262e99e64b471ef09bf00482cd3d9fa because of HTTP error 403 Client Error: Forbidden for url: https://dl.cloudsmith.io/pzvJ5VJQLGivg1uL/mark-testing/python-stuff/python/python_gitlab-3.1.1-py3-none-any.whl for URL https://dl.cloudsmith.io/pzvJ5VJQLGivg1uL/mark-testing/python-stuff/python/python_gitlab-3.1.1-py3-none-any.whl#sha256=2a7de39c8976db6d0db20031e71b3e43d262e99e64b471ef09bf00482cd3d9fa (from https://dl.cloudsmith.io/pzvJ5VJQLGivg1uL/mark-testing/python-stuff/python/simple/python-gitlab/) (requires-python:>=3.7.0)
+            """,
+            ("mark-testing", "python-stuff", "python-gitlab", "3.1.1"),
+    )
     ],
 )
-def test_parse_log_for_details_success_cases(log_text, expected):
-    assert parse_log_for_details(log_text) == expected
+def test_parse_logs_for_all_details_success_cases(log_text, expected):
+    all_matches = parse_logs_for_all_details(log_text, unique=True)
+    assert all_matches and all_matches[0] == expected
 
 
 def test_multiple_matches_returns_first():
     log = (
-        "403 https://dl.cloudsmith.io/public/first/ns/python/firstpkg-1.0.0.tar.gz\n"
-        "403 https://dl.cloudsmith.io/public/second/ns/python/secondpkg-2.0.0.whl\n"
+        "ERROR: Could not install requirement firstpkg==1.0.0 from https://dl.cloudsmith.io/public/first/ns/python/firstpkg-1.0.0.tar.gz because of HTTP error 403 Client Error: Forbidden for url\n"
+        "ERROR: Could not install requirement secondpkg==2.0.0 from https://dl.cloudsmith.io/public/second/ns/python/secondpkg-2.0.0.whl because of HTTP error 403 Client Error: Forbidden for url\n"
     )
-    assert parse_log_for_details(log) == ("first", "ns", "firstpkg", "1.0.0")
+    assert parse_logs_for_all_details(log)[0] == ("first", "ns", "firstpkg", "1.0.0")
+    assert parse_logs_for_all_details(log) == [
+        ("first", "ns", "firstpkg", "1.0.0"),
+        ("second", "ns", "secondpkg", "2.0.0"),
+    ]
 
 
-@pytest.mark.parametrize(
-    "log_text",
-    [
-        "No relevant URLs here",
-        # Version starts with 'v' (pattern requires digit at start of version)
-        "403 https://dl.cloudsmith.io/public/ns/repo/python/pkgname-v1.2.3.tar.gz",
-        # Missing python segment
-        "403 https://dl.cloudsmith.io/public/ns/repo/pkgname-1.2.3.tar.gz",
-        # Not a supported extension
-        "403 https://dl.cloudsmith.io/public/ns/repo/python/pkgname-1.2.3.txt",
-    ],
-)
-def test_parse_log_for_details_no_match(log_text):
-    assert parse_log_for_details(log_text) == (None, None, None, None)
+def test_multiple_matches_with_duplicates():
+    log = (
+        "ERROR: Could not install requirement dupkg==1.2.3 from https://dl.cloudsmith.io/public/acme/tools/python/dupkg-1.2.3.tar.gz because of HTTP error 403 Client Error: Forbidden for url\n"
+        "ERROR: Could not install requirement dupkg==1.2.3 from https://dl.cloudsmith.io/public/acme/tools/python/dupkg-1.2.3.tar.gz because of HTTP error 403 Client Error: Forbidden for url\n"  # duplicate
+        "ERROR: Could not install requirement other==2.0.0 from https://dl.cloudsmith.io/public/acme/tools/python/other-2.0.0.whl because of HTTP error 403 Client Error: Forbidden for url\n"
+    )
+    # unique=True default removes duplicate
+    assert parse_logs_for_all_details(log) == [
+        ("acme", "tools", "dupkg", "1.2.3"),
+        ("acme", "tools", "other", "2.0.0"),
+    ]
+    # unique=False keeps both occurrences
+    assert parse_logs_for_all_details(log, unique=False) == [
+        ("acme", "tools", "dupkg", "1.2.3"),
+        ("acme", "tools", "dupkg", "1.2.3"),
+        ("acme", "tools", "other", "2.0.0"),
+    ]
 
 
-def test_parse_log_for_details_complex_name_and_version():
-    log = "403 https://dl.cloudsmith.io/public/acme/tools/python/my.pkg_name-12.0.0.post1.tar.gz"
-    assert parse_log_for_details(log) == ("acme", "tools", "my.pkg_name", "12.0.0.post1")
+def test_parse_logs_for_all_details_complex_name_and_version():
+    log = "ERROR: Could not install requirement from https://dl.cloudsmith.io/public/acme/tools/python/my.pkg_name-12.0.0.post1.tar.gz because of HTTP error 403 Client Error: Forbidden for url"
+    assert parse_logs_for_all_details(log)[0] == ("acme", "tools", "my.pkg-name", "12.0.0")
+
+
+def test_parse_logs_for_all_details_no_version_in_error_line_but_artifact_present():
+    log = (
+        "ERROR: Could not install requirement python-gitlab from https://dl.cloudsmith.io/public/ws/repo/python/python_gitlab-6.3.0-py3-none-any.whl#sha256=abc because of HTTP error 403 Client Error: Forbidden for url"
+    )
+    assert parse_logs_for_all_details(log)[0] == ("ws", "repo", "python-gitlab", "6.3.0")

--- a/package_insights/test_package_insights_parse.py
+++ b/package_insights/test_package_insights_parse.py
@@ -1,102 +1,133 @@
 import pytest
 from package_insights.package_insights import parse_logs_for_all_details
+import importlib
 
 
-@pytest.mark.parametrize(
-    "log_text,expected",
-    [
-        (
-            """
-            Looking in indexes: https://dl.cloudsmith.io/pzvJ5VJQLGivg1uL/mark-testing/python-stuff/python/simple/
-            Collecting python-gitlab==3.1.1
-            WARNING: Retrying (Retry(total=4, connect=None, read=None, redirect=None, status=None)) after connection broken by 'ReadTimeoutError("HTTPSConnectionPool(host='dl.cloudsmith.io', port=443): Read timed out. (read timeout=15)")': /pzvJ5VJQLGivg1uL/mark-testing/python-stuff/python/python_gitlab-3.1.1-py3-none-any.whl
-            ERROR: HTTP error 403 while getting https://dl.cloudsmith.io/pzvJ5VJQLGivg1uL/mark-testing/python-stuff/python/python_gitlab-3.1.1-py3-none-any.whl#sha256=2a7de39c8976db6d0db20031e71b3e43d262e99e64b471ef09bf00482cd3d9fa (from https://dl.cloudsmith.io/pzvJ5VJQLGivg1uL/mark-testing/python-stuff/python/simple/python-gitlab/) (requires-python:>=3.7.0)
+class TestPythonLogParsing:
+    @pytest.fixture(autouse=True)
+    def only_python_parser(self, monkeypatch):
+        # Restrict PARSERS to only the Python parser for these tests
+        module = importlib.import_module("package_insights.package_insights")
+        PythonPipParser = getattr(module, "PythonPipParser")
+        monkeypatch.setattr(module, "PARSERS", [PythonPipParser()])
 
-            [notice] A new release of pip is available: 25.1.1 -> 25.2
-            [notice] To update, run: pip install --upgrade pip
-            ERROR: Could not install requirement python-gitlab==3.1.1 from https://dl.cloudsmith.io/pzvJ5VJQLGivg1uL/mark-testing/python-stuff/python/python_gitlab-3.1.1-py3-none-any.whl#sha256=2a7de39c8976db6d0db20031e71b3e43d262e99e64b471ef09bf00482cd3d9fa because of HTTP error 403 Client Error: Forbidden for url: https://dl.cloudsmith.io/pzvJ5VJQLGivg1uL/mark-testing/python-stuff/python/python_gitlab-3.1.1-py3-none-any.whl for URL https://dl.cloudsmith.io/pzvJ5VJQLGivg1uL/mark-testing/python-stuff/python/python_gitlab-3.1.1-py3-none-any.whl#sha256=2a7de39c8976db6d0db20031e71b3e43d262e99e64b471ef09bf00482cd3d9fa (from https://dl.cloudsmith.io/pzvJ5VJQLGivg1uL/mark-testing/python-stuff/python/simple/python-gitlab/) (requires-python:>=3.7.0)
-            """,
-            ("mark-testing", "python-stuff", "python-gitlab", "3.1.1"),
+    @pytest.mark.parametrize(
+        "log_text,expected",
+        [
+            (
+                """
+                Looking in indexes: https://dl.cloudsmith.io/pzvJ5VJQLGivg1uL/workspace-name/repository-name/python/simple/
+                Collecting python-gitlab==3.1.1
+                WARNING: Retrying (Retry(total=4, connect=None, read=None, redirect=None, status=None)) after connection broken by 'ReadTimeoutError("HTTPSConnectionPool(host='dl.cloudsmith.io', port=443): Read timed out. (read timeout=15)")': /pzvJ5VJQLGivg1uL/workspace-name/repository-name/python/python_gitlab-3.1.1-py3-none-any.whl
+                ERROR: HTTP error 403 while getting https://dl.cloudsmith.io/pzvJ5VJQLGivg1uL/workspace-name/repository-name/python/python_gitlab-3.1.1-py3-none-any.whl#sha256=2a7de39c8976db6d0db20031e71b3e43d262e99e64b471ef09bf00482cd3d9fa (from https://dl.cloudsmith.io/pzvJ5VJQLGivg1uL/workspace-name/repository-name/python/simple/python-gitlab/) (requires-python:>=3.7.0)
+
+                [notice] A new release of pip is available: 25.1.1 -> 25.2
+                [notice] To update, run: pip install --upgrade pip
+                ERROR: Could not install requirement python-gitlab==3.1.1 from https://dl.cloudsmith.io/pzvJ5VJQLGivg1uL/workspace-name/repository-name/python/python_gitlab-3.1.1-py3-none-any.whl#sha256=2a7de39c8976db6d0db20031e71b3e43d262e99e64b471ef09bf00482cd3d9fa because of HTTP error 403 Client Error: Forbidden for url: https://dl.cloudsmith.io/pzvJ5VJQLGivg1uL/workspace-name/repository-name/python/python_gitlab-3.1.1-py3-none-any.whl for URL https://dl.cloudsmith.io/pzvJ5VJQLGivg1uL/workspace-name/repository-name/python/python_gitlab-3.1.1-py3-none-any.whl#sha256=2a7de39c8976db6d0db20031e71b3e43d262e99e64b471ef09bf00482cd3d9fa (from https://dl.cloudsmith.io/pzvJ5VJQLGivg1uL/workspace-name/repository-name/python/simple/python-gitlab/) (requires-python:>=3.7.0)
+                """,
+                ("workspace-name", "repository-name", "python-gitlab", "3.1.1"),
+            )
+        ],
     )
-    ],
-)
-def test_parse_logs_for_all_details_success_cases(log_text, expected):
-    all_matches = parse_logs_for_all_details(log_text, unique=True)
-    assert all_matches and all_matches[0] == expected
+    def test_python_parse_logs_for_all_details_success_cases(self, log_text, expected):
+        all_matches = parse_logs_for_all_details(log_text, unique=True)
+        assert all_matches and all_matches[0] == expected
+
+    def test_python_multiple_matches_returns_in_order(self):
+        log = (
+            "ERROR: Could not install requirement firstpkg==1.0.0 from https://dl.cloudsmith.io/public/first/ns/python/firstpkg-1.0.0.tar.gz because of HTTP error 403 Client Error: Forbidden for url\n"
+            "ERROR: Could not install requirement secondpkg==2.0.0 from https://dl.cloudsmith.io/public/second/ns/python/secondpkg-2.0.0.whl because of HTTP error 403 Client Error: Forbidden for url\n"
+        )
+        assert parse_logs_for_all_details(log)[0] == ("first", "ns", "firstpkg", "1.0.0")
+        assert parse_logs_for_all_details(log) == [
+            ("first", "ns", "firstpkg", "1.0.0"),
+            ("second", "ns", "secondpkg", "2.0.0"),
+        ]
+
+    def test_python_multiple_matches_with_duplicates(self):
+        log = (
+            "ERROR: Could not install requirement dupkg==1.2.3 from https://dl.cloudsmith.io/public/acme/tools/python/dupkg-1.2.3.tar.gz because of HTTP error 403 Client Error: Forbidden for url\n"
+            "ERROR: Could not install requirement dupkg==1.2.3 from https://dl.cloudsmith.io/public/acme/tools/python/dupkg-1.2.3.tar.gz because of HTTP error 403 Client Error: Forbidden for url\n"  # duplicate
+            "ERROR: Could not install requirement other==2.0.0 from https://dl.cloudsmith.io/public/acme/tools/python/other-2.0.0.whl because of HTTP error 403 Client Error: Forbidden for url\n"
+        )
+        assert parse_logs_for_all_details(log) == [
+            ("acme", "tools", "dupkg", "1.2.3"),
+            ("acme", "tools", "other", "2.0.0"),
+        ]
+
+    def test_python_parse_logs_for_all_details_complex_name_and_version(self):
+        log = "ERROR: Could not install requirement from https://dl.cloudsmith.io/public/acme/tools/python/my.pkg_name-12.0.0.post1.tar.gz because of HTTP error 403 Client Error: Forbidden for url"
+        assert parse_logs_for_all_details(log)[0] == ("acme", "tools", "my.pkg-name", "12.0.0.post1")
+
+    def test_python_parse_logs_for_all_details_no_version_in_error_line_but_artifact_present(self):
+        log = (
+            "ERROR: Could not install requirement python-gitlab from https://dl.cloudsmith.io/public/ws/repo/python/python_gitlab-6.3.0-py3-none-any.whl#sha256=abc because of HTTP error 403 Client Error: Forbidden for url"
+        )
+        assert parse_logs_for_all_details(log)[0] == ("ws", "repo", "python-gitlab", "6.3.0")
 
 
-def test_multiple_matches_returns_first():
-    log = (
-        "ERROR: Could not install requirement firstpkg==1.0.0 from https://dl.cloudsmith.io/public/first/ns/python/firstpkg-1.0.0.tar.gz because of HTTP error 403 Client Error: Forbidden for url\n"
-        "ERROR: Could not install requirement secondpkg==2.0.0 from https://dl.cloudsmith.io/public/second/ns/python/secondpkg-2.0.0.whl because of HTTP error 403 Client Error: Forbidden for url\n"
-    )
-    assert parse_logs_for_all_details(log)[0] == ("first", "ns", "firstpkg", "1.0.0")
-    assert parse_logs_for_all_details(log) == [
-        ("first", "ns", "firstpkg", "1.0.0"),
-        ("second", "ns", "secondpkg", "2.0.0"),
-    ]
+class TestNpmLogParsing:
+    @pytest.fixture(autouse=True)
+    def only_npm_parser(self, monkeypatch):
+        # Restrict PARSERS to only the Npm parser for these tests
+        module = importlib.import_module("package_insights.package_insights")
+        NpmParser = getattr(module, "NpmParser")
+        monkeypatch.setattr(module, "PARSERS", [NpmParser()])
+
+    def test_parse_npm_signed_fetch_lines(self):
+        log = (
+            "npm http fetch GET 403 https://dl.cloudsmith.io/signed/workspace-name/repository-name/upstream/filename/npm/xml2js/xml2js-0.6.2.tgz?created=1&expires=2 10ms\n"
+            "npm http fetch GET 403 https://dl.cloudsmith.io/signed/workspace-name/repository-name/upstream/filename/npm/jmespath/jmespath-0.16.0.tgz?created=1&expires=2 11ms\n"
+            "npm error 403 403 Forbidden - GET https://npm.cloudsmith.io/workspace-name/repository-name/xmlbuilder/-/xmlbuilder-11.0.1.tgz - Package is quarantined.\n"
+        )
+        matches = parse_logs_for_all_details(log)
+        assert ("workspace-name", "repository-name", "xml2js", "0.6.2") in matches
+        assert ("workspace-name", "repository-name", "jmespath", "0.16.0") in matches
+
+    def test_parse_npm_error_direct_quarantine_line(self):
+        log = (
+            "npm error code E403\n"
+            "npm error 403 403 Forbidden - GET https://npm.cloudsmith.io/workspace-name/repository-name/xmlbuilder/-/xmlbuilder-11.0.1.tgz - Package is quarantined.\n"
+        )
+        matches = parse_logs_for_all_details(log)
+        assert matches[0] == ("workspace-name", "repository-name", "xmlbuilder", "11.0.1")
+
+    def test_parse_npm_error_signed_line(self):
+        log = (
+            "npm error code E403\n"
+            "npm error 403 403 Forbidden - GET https://dl.cloudsmith.io/signed/workspace-name/repository-name/upstream/filename/npm/vary/vary-1.1.2.tgz?created=1&expires=2\n"
+        )
+        matches = parse_logs_for_all_details(log)
+        assert matches[0] == ("workspace-name", "repository-name", "vary", "1.1.2")
+
+    def test_parse_multiple_npm_direct_fetch_lines(self):
+        log = (
+            "npm http fetch GET 403 https://npm.cloudsmith.io/workspace-name/repository-name/xmlbuilder/-/xmlbuilder-11.0.1.tgz 10ms (cache skip)\n"
+            "npm http fetch GET 403 https://npm.cloudsmith.io/workspace-name/repository-name/querystring/-/querystring-0.2.0.tgz 11ms (cache skip)\n"
+            "npm http fetch GET 403 https://npm.cloudsmith.io/workspace-name/repository-name/url/-/url-0.10.3.tgz 12ms (cache skip)\n"
+        )
+        matches = parse_logs_for_all_details(log)
+        assert ("workspace-name", "repository-name", "xmlbuilder", "11.0.1") in matches
+        assert ("workspace-name", "repository-name", "querystring", "0.2.0") in matches
+        assert ("workspace-name", "repository-name", "url", "0.10.3") in matches
 
 
-def test_multiple_matches_with_duplicates():
-    log = (
-        "ERROR: Could not install requirement dupkg==1.2.3 from https://dl.cloudsmith.io/public/acme/tools/python/dupkg-1.2.3.tar.gz because of HTTP error 403 Client Error: Forbidden for url\n"
-        "ERROR: Could not install requirement dupkg==1.2.3 from https://dl.cloudsmith.io/public/acme/tools/python/dupkg-1.2.3.tar.gz because of HTTP error 403 Client Error: Forbidden for url\n"  # duplicate
-        "ERROR: Could not install requirement other==2.0.0 from https://dl.cloudsmith.io/public/acme/tools/python/other-2.0.0.whl because of HTTP error 403 Client Error: Forbidden for url\n"
-    )
-    assert parse_logs_for_all_details(log) == [
-        ("acme", "tools", "dupkg", "1.2.3"),
-        ("acme", "tools", "other", "2.0.0"),
-    ]
+class TestLogParsing:
+    # Test Parsing works with all parsers present
 
+    def test_parse_python_error_single_package(self):
+        log = (
+            "ERROR: Could not install requirement foo==2.0.0 from https://dl.cloudsmith.io/public/acme/tools/python/foo-2.0.0.whl because of HTTP error 403 Client Error: Forbidden for url\n"
+        )
+        assert parse_logs_for_all_details(log) == [
+            ("acme", "tools", "foo", "2.0.0"),
+        ]
 
-def test_parse_logs_for_all_details_complex_name_and_version():
-    log = "ERROR: Could not install requirement from https://dl.cloudsmith.io/public/acme/tools/python/my.pkg_name-12.0.0.post1.tar.gz because of HTTP error 403 Client Error: Forbidden for url"
-    assert parse_logs_for_all_details(log)[0] == ("acme", "tools", "my.pkg-name", "12.0.0.post1")
+    def test_parse_npm_error_single_package(self):
+        log = (
+            "npm error code E403\n"
+            "npm error 403 403 Forbidden - GET https://npm.cloudsmith.io/workspace-name/repository-name/xmlbuilder/-/xmlbuilder-11.0.1.tgz - Package is quarantined.\n"
+        )
+        matches = parse_logs_for_all_details(log)
+        assert matches[0] == ("workspace-name", "repository-name", "xmlbuilder", "11.0.1")
 
-
-def test_parse_logs_for_all_details_no_version_in_error_line_but_artifact_present():
-    log = (
-        "ERROR: Could not install requirement python-gitlab from https://dl.cloudsmith.io/public/ws/repo/python/python_gitlab-6.3.0-py3-none-any.whl#sha256=abc because of HTTP error 403 Client Error: Forbidden for url"
-    )
-    assert parse_logs_for_all_details(log)[0] == ("ws", "repo", "python-gitlab", "6.3.0")
-
-
-def test_parse_npm_signed_fetch_lines():
-    log = (
-        "npm http fetch GET 403 https://dl.cloudsmith.io/signed/mark-testing/python-stuff/upstream/filename/npm/xml2js/xml2js-0.6.2.tgz?created=1&expires=2 10ms\n"
-        "npm http fetch GET 403 https://dl.cloudsmith.io/signed/mark-testing/python-stuff/upstream/filename/npm/jmespath/jmespath-0.16.0.tgz?created=1&expires=2 11ms\n"
-        "npm error 403 403 Forbidden - GET https://npm.cloudsmith.io/mark-testing/python-stuff/xmlbuilder/-/xmlbuilder-11.0.1.tgz - Package is quarantined.\n"
-    )
-    matches = parse_logs_for_all_details(log)
-    assert ("mark-testing", "python-stuff", "xml2js", "0.6.2") in matches
-    assert ("mark-testing", "python-stuff", "jmespath", "0.16.0") in matches
-
-
-def test_parse_npm_error_direct_quarantine_line():
-    log = (
-        "npm error code E403\n"
-        "npm error 403 403 Forbidden - GET https://npm.cloudsmith.io/mark-testing/python-stuff/xmlbuilder/-/xmlbuilder-11.0.1.tgz - Package is quarantined.\n"
-    )
-    matches = parse_logs_for_all_details(log)
-    assert matches[0] == ("mark-testing", "python-stuff", "xmlbuilder", "11.0.1")
-
-
-def test_parse_npm_error_signed_line():
-    log = (
-        "npm error code E403\n"
-        "npm error 403 403 Forbidden - GET https://dl.cloudsmith.io/signed/mark-testing/python-stuff/upstream/filename/npm/vary/vary-1.1.2.tgz?created=1&expires=2\n"
-    )
-    matches = parse_logs_for_all_details(log)
-    assert matches[0] == ("mark-testing", "python-stuff", "vary", "1.1.2")
-
-
-def test_parse_multiple_npm_direct_fetch_lines():
-    log = (
-        "npm http fetch GET 403 https://npm.cloudsmith.io/mark-testing/python-stuff/xmlbuilder/-/xmlbuilder-11.0.1.tgz 10ms (cache skip)\n"
-        "npm http fetch GET 403 https://npm.cloudsmith.io/mark-testing/python-stuff/querystring/-/querystring-0.2.0.tgz 11ms (cache skip)\n"
-        "npm http fetch GET 403 https://npm.cloudsmith.io/mark-testing/python-stuff/url/-/url-0.10.3.tgz 12ms (cache skip)\n"
-    )
-    matches = parse_logs_for_all_details(log)
-    assert ("mark-testing", "python-stuff", "xmlbuilder", "11.0.1") in matches
-    assert ("mark-testing", "python-stuff", "querystring", "0.2.0") in matches
-    assert ("mark-testing", "python-stuff", "url", "0.10.3") in matches

--- a/package_insights/test_package_insights_parse.py
+++ b/package_insights/test_package_insights_parse.py
@@ -43,14 +43,7 @@ def test_multiple_matches_with_duplicates():
         "ERROR: Could not install requirement dupkg==1.2.3 from https://dl.cloudsmith.io/public/acme/tools/python/dupkg-1.2.3.tar.gz because of HTTP error 403 Client Error: Forbidden for url\n"  # duplicate
         "ERROR: Could not install requirement other==2.0.0 from https://dl.cloudsmith.io/public/acme/tools/python/other-2.0.0.whl because of HTTP error 403 Client Error: Forbidden for url\n"
     )
-    # unique=True default removes duplicate
     assert parse_logs_for_all_details(log) == [
-        ("acme", "tools", "dupkg", "1.2.3"),
-        ("acme", "tools", "other", "2.0.0"),
-    ]
-    # unique=False keeps both occurrences
-    assert parse_logs_for_all_details(log, unique=False) == [
-        ("acme", "tools", "dupkg", "1.2.3"),
         ("acme", "tools", "dupkg", "1.2.3"),
         ("acme", "tools", "other", "2.0.0"),
     ]
@@ -58,7 +51,7 @@ def test_multiple_matches_with_duplicates():
 
 def test_parse_logs_for_all_details_complex_name_and_version():
     log = "ERROR: Could not install requirement from https://dl.cloudsmith.io/public/acme/tools/python/my.pkg_name-12.0.0.post1.tar.gz because of HTTP error 403 Client Error: Forbidden for url"
-    assert parse_logs_for_all_details(log)[0] == ("acme", "tools", "my.pkg-name", "12.0.0")
+    assert parse_logs_for_all_details(log)[0] == ("acme", "tools", "my.pkg-name", "12.0.0.post1")
 
 
 def test_parse_logs_for_all_details_no_version_in_error_line_but_artifact_present():
@@ -66,3 +59,44 @@ def test_parse_logs_for_all_details_no_version_in_error_line_but_artifact_presen
         "ERROR: Could not install requirement python-gitlab from https://dl.cloudsmith.io/public/ws/repo/python/python_gitlab-6.3.0-py3-none-any.whl#sha256=abc because of HTTP error 403 Client Error: Forbidden for url"
     )
     assert parse_logs_for_all_details(log)[0] == ("ws", "repo", "python-gitlab", "6.3.0")
+
+
+def test_parse_npm_signed_fetch_lines():
+    log = (
+        "npm http fetch GET 403 https://dl.cloudsmith.io/signed/mark-testing/python-stuff/upstream/filename/npm/xml2js/xml2js-0.6.2.tgz?created=1&expires=2 10ms\n"
+        "npm http fetch GET 403 https://dl.cloudsmith.io/signed/mark-testing/python-stuff/upstream/filename/npm/jmespath/jmespath-0.16.0.tgz?created=1&expires=2 11ms\n"
+        "npm error 403 403 Forbidden - GET https://npm.cloudsmith.io/mark-testing/python-stuff/xmlbuilder/-/xmlbuilder-11.0.1.tgz - Package is quarantined.\n"
+    )
+    matches = parse_logs_for_all_details(log)
+    assert ("mark-testing", "python-stuff", "xml2js", "0.6.2") in matches
+    assert ("mark-testing", "python-stuff", "jmespath", "0.16.0") in matches
+
+
+def test_parse_npm_error_direct_quarantine_line():
+    log = (
+        "npm error code E403\n"
+        "npm error 403 403 Forbidden - GET https://npm.cloudsmith.io/mark-testing/python-stuff/xmlbuilder/-/xmlbuilder-11.0.1.tgz - Package is quarantined.\n"
+    )
+    matches = parse_logs_for_all_details(log)
+    assert matches[0] == ("mark-testing", "python-stuff", "xmlbuilder", "11.0.1")
+
+
+def test_parse_npm_error_signed_line():
+    log = (
+        "npm error code E403\n"
+        "npm error 403 403 Forbidden - GET https://dl.cloudsmith.io/signed/mark-testing/python-stuff/upstream/filename/npm/vary/vary-1.1.2.tgz?created=1&expires=2\n"
+    )
+    matches = parse_logs_for_all_details(log)
+    assert matches[0] == ("mark-testing", "python-stuff", "vary", "1.1.2")
+
+
+def test_parse_multiple_npm_direct_fetch_lines():
+    log = (
+        "npm http fetch GET 403 https://npm.cloudsmith.io/mark-testing/python-stuff/xmlbuilder/-/xmlbuilder-11.0.1.tgz 10ms (cache skip)\n"
+        "npm http fetch GET 403 https://npm.cloudsmith.io/mark-testing/python-stuff/querystring/-/querystring-0.2.0.tgz 11ms (cache skip)\n"
+        "npm http fetch GET 403 https://npm.cloudsmith.io/mark-testing/python-stuff/url/-/url-0.10.3.tgz 12ms (cache skip)\n"
+    )
+    matches = parse_logs_for_all_details(log)
+    assert ("mark-testing", "python-stuff", "xmlbuilder", "11.0.1") in matches
+    assert ("mark-testing", "python-stuff", "querystring", "0.2.0") in matches
+    assert ("mark-testing", "python-stuff", "url", "0.10.3") in matches


### PR DESCRIPTION
This PR creates parser classes for python and NPM. 

* The parser classes check if the logs match their package format and then performs some log extraction and normalisation
* The CLI tool will iterate through parser classes until it gets a match back

These parser classes will automatically get multiple logs. Example screenshot below is based on the output of `npm i aws-sdk --loglevel verbose` when all packages are blocked.

<img width="1167" height="1678" alt="image" src="https://github.com/user-attachments/assets/672a0f95-2d20-4714-afbc-e415fce12fcf" />
