### PR TITLE
ci(ENG-9648): add workflow and config to create semantic release and publish image

### DIFF
--- a/.github/workflows/build-and-publish-docker-image.yml
+++ b/.github/workflows/build-and-publish-docker-image.yml
@@ -30,7 +30,7 @@ jobs:
               if: steps.semantic_release.outputs.new_release_published == 'true'
               run: |
                   docker build -t ${{ env.DOCKER_IMAGE_NAME }}:${{ env.VERSION }} package_insights/
-            - name: Push Docker image to Cloudsmith/
+            - name: Push Docker image to Cloudsmith
               id: push_dockerised_cli_cloudsmith
               if: steps.semantic_release.outputs.new_release_published == 'true'
               run: |

--- a/.github/workflows/build-and-publish-docker-image.yml
+++ b/.github/workflows/build-and-publish-docker-image.yml
@@ -6,7 +6,8 @@ on:
             - "main"
 
 permissions:
-    contents: write
+    id-token: write # Required for OIDC authentication
+    contents: read # Required for actions/checkout
 jobs:
     build:
         runs-on: ubuntu-latest
@@ -25,11 +26,12 @@ jobs:
               id: get_version
               if: steps.semantic_release.outputs.new_release_published == 'true'
               run: echo "VERSION=${{ steps.semantic_release.outputs.new_release_version }}" >> $GITHUB_ENV
-            - name: Install and authenticate Cloudsmith CLI
+            - name: Authenticate with Cloudsmith via OIDC
               uses: cloudsmith-io/cloudsmith-cli-action@v1.0.3
               with:
                   oidc-namespace: ${{ vars.CLOUDSMITH_NAMESPACE }}
                   oidc-service-slug: ${{ vars.CLOUDSMITH_SERVICE_USER }}
+                  oidc-auth-only: 'true' # The action only performs authentication
             - name: Build Docker image
               id: build_insights_image
               if: steps.semantic_release.outputs.new_release_published == 'true'

--- a/.github/workflows/build-and-publish-docker-image.yml
+++ b/.github/workflows/build-and-publish-docker-image.yml
@@ -33,6 +33,8 @@ jobs:
             - name: Push Docker image to Cloudsmith
               id: push_dockerised_cli_cloudsmith
               if: steps.semantic_release.outputs.new_release_published == 'true'
+              env:
+                  CLOUDSMITH_API_KEY: ${{ secrets.CLOUDSMITH_API_KEY }}
               run: |
                   echo "${CLOUDSMITH_API_KEY}" | docker login docker.cloudsmith.io -u ${{ vars.CLOUDSMITH_SERVICE_USER }} --password-stdin
                   docker push ${{ env.DOCKER_IMAGE_NAME }}:${{ env.VERSION }}

--- a/.github/workflows/build-and-publish-docker-image.yml
+++ b/.github/workflows/build-and-publish-docker-image.yml
@@ -6,7 +6,7 @@ on:
             - "main"
 
 permissions:
- contents: write
+    contents: write
 jobs:
     build:
         runs-on: ubuntu-latest

--- a/.github/workflows/build-and-publish-docker-image.yml
+++ b/.github/workflows/build-and-publish-docker-image.yml
@@ -25,16 +25,19 @@ jobs:
               id: get_version
               if: steps.semantic_release.outputs.new_release_published == 'true'
               run: echo "VERSION=${{ steps.semantic_release.outputs.new_release_version }}" >> $GITHUB_ENV
+            - name: Install and authenticate Cloudsmith CLI
+              uses: cloudsmith-io/cloudsmith-cli-action@v1.0.3
+              with:
+                  oidc-namespace: ${{ vars.CLOUDSMITH_NAMESPACE }}
+                  oidc-service-slug: ${{ vars.CLOUDSMITH_SERVICE_USER }}
             - name: Build Docker image
               id: build_insights_image
               if: steps.semantic_release.outputs.new_release_published == 'true'
               run: |
                   docker build -t ${{ env.DOCKER_IMAGE_NAME }}:${{ env.VERSION }} package_insights/
             - name: Push Docker image to Cloudsmith
-              id: push_dockerised_cli_cloudsmith
+              id: push_docker_image_cloudsmith
               if: steps.semantic_release.outputs.new_release_published == 'true'
-              env:
-                  CLOUDSMITH_API_KEY: ${{ secrets.CLOUDSMITH_API_KEY }}
               run: |
                   echo "${CLOUDSMITH_API_KEY}" | docker login docker.cloudsmith.io -u ${{ vars.CLOUDSMITH_SERVICE_USER }} --password-stdin
                   docker push ${{ env.DOCKER_IMAGE_NAME }}:${{ env.VERSION }}

--- a/.github/workflows/build-and-publish-docker-image.yml
+++ b/.github/workflows/build-and-publish-docker-image.yml
@@ -1,0 +1,38 @@
+name: Release and Publish Docker image
+
+on:
+    push:
+        branches:
+            - "main"
+
+permissions:
+ contents: write
+jobs:
+    build:
+        runs-on: ubuntu-latest
+        env:
+            DOCKER_IMAGE_NAME: docker.cloudsmith.io/${{ vars.CLOUDSMITH_NAMESPACE }}/package-insights/package-insights
+        steps:
+            - uses: actions/checkout@v4
+              with:
+                  fetch-depth: 0
+            - name: Semantic Release
+              id: semantic_release
+              uses: cycjimmy/semantic-release-action@v4
+              env:
+                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+            - name: Get version from semantic release
+              id: get_version
+              if: steps.semantic_release.outputs.new_release_published == 'true'
+              run: echo "VERSION=${{ steps.semantic_release.outputs.new_release_version }}" >> $GITHUB_ENV
+            - name: Build Docker image
+              id: build_insights_image
+              if: steps.semantic_release.outputs.new_release_published == 'true'
+              run: |
+                  docker build -t ${{ env.DOCKER_IMAGE_NAME }}:${{ env.VERSION }} package_insights/
+            - name: Push Docker image to Cloudsmith/
+              id: push_dockerised_cli_cloudsmith
+              if: steps.semantic_release.outputs.new_release_published == 'true'
+              run: |
+                  echo "${CLOUDSMITH_API_KEY}" | docker login docker.cloudsmith.io -u ${{ vars.CLOUDSMITH_SERVICE_USER }} --password-stdin
+                  docker push ${{ env.DOCKER_IMAGE_NAME }}:${{ env.VERSION }}

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -1,0 +1,26 @@
+{
+  "branches": ["main"],
+  "plugins": [
+    [
+      "@semantic-release/commit-analyzer",
+      {
+        "releaseRules": [
+          {"type": "feat", "release": "minor"},
+          {"type": "fix", "release": "patch"},
+          {"type": "perf", "release": "patch"},
+          {"type": "revert", "release": "patch"},
+          {"type": "docs", "release": false},
+          {"type": "style", "release": false},
+          {"type": "chore", "release": false},
+          {"type": "refactor", "release": "patch"},
+          {"type": "test", "release": false},
+          {"type": "build", "release": false},
+          {"type": "ci", "release": false},
+          {"breaking": true, "release": "minor"}
+        ]
+      }
+    ],
+    "@semantic-release/release-notes-generator",
+    "@semantic-release/github"
+  ]
+}


### PR DESCRIPTION
## Add Release Step
This PR adds an action to create a semantic release based on commits.

This line in the release config ensures that while package_insights and the action is in alpha the major version won't change ie it won't release `1.x.y`, only `0.x.y` regardless of commits.
```
{"breaking": true, "release": "minor"}
```


## Add Build and Publish Step
If a release is created this will also build and publish a `package-insights` docker image. Vars and secrets have been created in the repo and a repository has been created in cloudsmith.io with public broadcasting enabled so customers can download the `package-insights` tool and try it in their CICD and other development environments.
