### PR TITLE
ci(ENG-9648): add minimal permissions needed for semantic release action

### DIFF
--- a/.github/workflows/build-and-publish-docker-image.yml
+++ b/.github/workflows/build-and-publish-docker-image.yml
@@ -8,15 +8,13 @@ on:
         branches:
             - "main"
 
-permissions:
-    id-token: write # Required for OIDC authentication
-    contents: read # Required for actions/checkout
 jobs:
     build:
         runs-on: ubuntu-latest
         permissions:
             contents: write # to be able to publish a GitHub release
             pull-requests: write # to be able to comment on released pull requests
+            id-token: write # Required for OIDC authentication
         env:
             DOCKER_IMAGE_NAME: docker.cloudsmith.io/${{ vars.CLOUDSMITH_NAMESPACE }}/package-insights/package-insights
         steps:

--- a/.github/workflows/build-and-publish-docker-image.yml
+++ b/.github/workflows/build-and-publish-docker-image.yml
@@ -4,6 +4,9 @@ on:
     push:
         branches:
             - "main"
+    pull_request:
+        branches:
+            - "main"
 
 permissions:
     id-token: write # Required for OIDC authentication
@@ -25,24 +28,31 @@ jobs:
               uses: cycjimmy/semantic-release-action@v4
               env:
                   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+              with:
+                  dry_run: ${{ github.event_name == 'pull_request' }}
             - name: Get version from semantic release
               id: get_version
-              if: steps.semantic_release.outputs.new_release_published == 'true'
-              run: echo "VERSION=${{ steps.semantic_release.outputs.new_release_version }}" >> $GITHUB_ENV
+              run: |
+                  if [ "${{ github.event_name }}" = "pull_request" ]; then
+                      echo "VERSION=pr-${{ github.event.number }}-${{ github.sha }}" >> $GITHUB_ENV
+                  elif [ "${{ steps.semantic_release.outputs.new_release_published }}" = "true" ]; then
+                      echo "VERSION=${{ steps.semantic_release.outputs.new_release_version }}" >> $GITHUB_ENV
+                  fi
             - name: Authenticate with Cloudsmith via OIDC
               uses: cloudsmith-io/cloudsmith-cli-action@v1.0.3
+              if: github.event_name == 'pull_request' || steps.semantic_release.outputs.new_release_published == 'true'
               with:
                   oidc-namespace: ${{ vars.CLOUDSMITH_NAMESPACE }}
                   oidc-service-slug: ${{ vars.CLOUDSMITH_SERVICE_USER }}
                   oidc-auth-only: 'true' # The action only performs authentication
             - name: Build Docker image
               id: build_insights_image
-              if: steps.semantic_release.outputs.new_release_published == 'true'
+              if: github.event_name == 'pull_request' || steps.semantic_release.outputs.new_release_published == 'true'
               run: |
                   docker build -t ${{ env.DOCKER_IMAGE_NAME }}:${{ env.VERSION }} package_insights/
             - name: Push Docker image to Cloudsmith
               id: push_docker_image_cloudsmith
-              if: steps.semantic_release.outputs.new_release_published == 'true'
+              if: github.event_name == 'push' && steps.semantic_release.outputs.new_release_published == 'true'
               run: |
                   echo "${CLOUDSMITH_API_KEY}" | docker login docker.cloudsmith.io -u ${{ vars.CLOUDSMITH_SERVICE_USER }} --password-stdin
                   docker push ${{ env.DOCKER_IMAGE_NAME }}:${{ env.VERSION }}

--- a/.github/workflows/build-and-publish-docker-image.yml
+++ b/.github/workflows/build-and-publish-docker-image.yml
@@ -11,6 +11,9 @@ permissions:
 jobs:
     build:
         runs-on: ubuntu-latest
+        permissions:
+            contents: write # to be able to publish a GitHub release
+            pull-requests: write # to be able to comment on released pull requests
         env:
             DOCKER_IMAGE_NAME: docker.cloudsmith.io/${{ vars.CLOUDSMITH_NAMESPACE }}/package-insights/package-insights
         steps:


### PR DESCRIPTION
Based on the docs here:
https://github.com/semantic-release/semantic-release/blob/master/docs/recipes/ci-configurations/github-actions.md#githubworkflowsreleaseyml-configuration-for-node-projects

Not adding issues or token permissions as I don't want the tool creating issues and it doesn't need npm provenance. 